### PR TITLE
Remove dynamic exception spefications.

### DIFF
--- a/src/del_op.cpp
+++ b/src/del_op.cpp
@@ -24,7 +24,7 @@
 #include <cstdlib>
 #include <func_exception>
 
-_UCXXEXPORT void operator delete(void* ptr) throw(){
+_UCXXEXPORT void operator delete(void* ptr) {
 	free(ptr);
 }
 

--- a/src/del_opnt.cpp
+++ b/src/del_opnt.cpp
@@ -22,7 +22,7 @@
 #include <func_exception>
 
 #ifndef NO_NOTHROW
-_UCXXEXPORT void operator delete(void* ptr, const std::nothrow_t& ) throw() {
+_UCXXEXPORT void operator delete(void* ptr, const std::nothrow_t& ) {
 	free(ptr);
 }
 #endif

--- a/src/del_ops.cpp
+++ b/src/del_ops.cpp
@@ -22,6 +22,6 @@
 #include <cstdlib>
 #include <func_exception>
 
-_UCXXEXPORT void operator delete(void* ptr, std::size_t) throw(){
+_UCXXEXPORT void operator delete(void* ptr, std::size_t) {
 	::operator delete (ptr);
 }

--- a/src/del_opv.cpp
+++ b/src/del_opv.cpp
@@ -24,7 +24,7 @@
 #include <cstdlib>
 #include <func_exception>
 
-_UCXXEXPORT void operator delete[](void * ptr) throw(){
+_UCXXEXPORT void operator delete[](void * ptr) {
 	free(ptr);
 }
 

--- a/src/del_opvnt.cpp
+++ b/src/del_opvnt.cpp
@@ -22,7 +22,7 @@
 #include <func_exception>
 
 #ifndef NO_NOTHROW
-_UCXXEXPORT void operator delete[](void* ptr, const std::nothrow_t& ) throw(){
+_UCXXEXPORT void operator delete[](void* ptr, const std::nothrow_t& ) {
 	free(ptr);
 }
 #endif

--- a/src/del_opvs.cpp
+++ b/src/del_opvs.cpp
@@ -22,6 +22,6 @@
 #include <cstdlib>
 #include <func_exception>
 
-_UCXXEXPORT void operator delete[](void * ptr, std::size_t) throw(){
+_UCXXEXPORT void operator delete[](void * ptr, std::size_t) {
 	::operator delete[] (ptr);
 }

--- a/src/eh_alloc.cpp
+++ b/src/eh_alloc.cpp
@@ -27,7 +27,7 @@
 namespace __cxxabiv1
 {
 
-extern "C" void * __cxa_allocate_exception(std::size_t thrown_size) throw(){
+extern "C" void * __cxa_allocate_exception(std::size_t thrown_size) {
 	void *e;
 	// The sizeof crap is required by Itanium ABI because we need to
 	// provide space for accounting information which is implementation
@@ -40,12 +40,12 @@ extern "C" void * __cxa_allocate_exception(std::size_t thrown_size) throw(){
 	return (void *)((unsigned char *)e + sizeof(__cxa_refcounted_exception));
 }
 
-extern "C" void __cxa_free_exception(void *vptr) throw(){
+extern "C" void __cxa_free_exception(void *vptr) {
 	free( (char *)(vptr) - sizeof(__cxa_refcounted_exception) );
 }
 
 
-extern "C" __cxa_dependent_exception * __cxa_allocate_dependent_exception() throw(){
+extern "C" __cxa_dependent_exception * __cxa_allocate_dependent_exception() {
 	__cxa_dependent_exception *retval;
 	// The sizeof crap is required by Itanium ABI because we need to
 	// provide space for accounting information which is implementation
@@ -58,7 +58,7 @@ extern "C" __cxa_dependent_exception * __cxa_allocate_dependent_exception() thro
 	return retval;
 }
 
-extern "C" void __cxa_free_dependent_exception(__cxa_dependent_exception *vptr) throw(){
+extern "C" void __cxa_free_dependent_exception(__cxa_dependent_exception *vptr) {
 	free( (char *)(vptr) );
 }
 

--- a/src/eh_globals.cpp
+++ b/src/eh_globals.cpp
@@ -31,11 +31,11 @@ namespace __cxxabiv1{
 
 static __UCLIBCXX_TLS __cxa_eh_globals eh_globals;
 
-extern "C" __cxa_eh_globals* __cxa_get_globals() throw(){
+extern "C" __cxa_eh_globals* __cxa_get_globals() {
 	return &eh_globals;
 }
 
-extern "C" __cxa_eh_globals* __cxa_get_globals_fast() throw(){
+extern "C" __cxa_eh_globals* __cxa_get_globals_fast() {
 	return &eh_globals;
 }
 

--- a/src/exception
+++ b/src/exception
@@ -54,11 +54,11 @@ namespace std
   class exception
   {
   public:
-    exception() throw() { }
-    virtual ~exception() throw();
+    exception() { }
+    virtual ~exception();
     /** Returns a C-style character string describing the general cause
      *  of the current error.  */
-    virtual const char* what() const throw();
+    virtual const char* what() const;
   };
 
   /** If an %exception is thrown which is not listed in a function's
@@ -66,10 +66,10 @@ namespace std
   class bad_exception : public exception
   {
   public:
-    bad_exception() throw() { }
+    bad_exception() { }
     // This declaration is not useless:
     // http://gcc.gnu.org/onlinedocs/gcc-3.0.2/gcc_6.html#SEC118
-    virtual ~bad_exception() throw();
+    virtual ~bad_exception();
   };
 
   /// If you write a replacement %terminate handler, it must be of this type.
@@ -78,13 +78,13 @@ namespace std
   typedef void (*unexpected_handler) ();
 
   /// Takes a new handler function as an argument, returns the old function.
-  terminate_handler set_terminate(terminate_handler) throw();
+  terminate_handler set_terminate(terminate_handler);
   /** The runtime will call this function if %exception handling must be
    *  abandoned for any reason.  */
   void terminate() __UCLIBCXX_NORETURN;
 
   /// Takes a new handler function as an argument, returns the old function.
-  unexpected_handler set_unexpected(unexpected_handler) throw();
+  unexpected_handler set_unexpected(unexpected_handler);
   /** The runtime will call this function if an %exception is thrown which
    *  violates the function's %exception specification.  */
   void unexpected() __UCLIBCXX_NORETURN;
@@ -99,7 +99,7 @@ namespace std
    *  2:  "When @c uncaught_exception() is true, throwing an %exception can
    *  result in a call of @c terminate() (15.5.1)."
    */
-  bool uncaught_exception() throw();
+  bool uncaught_exception();
 } // namespace std
 
 namespace __gnu_cxx

--- a/src/exception.cpp
+++ b/src/exception.cpp
@@ -33,15 +33,15 @@ namespace std{
 	//We are providing our own versions to be sneaky
 
 
-	_UCXXEXPORT exception::~exception() throw(){
+	_UCXXEXPORT exception::~exception() {
 		//Empty function
 	}
 
-	_UCXXEXPORT const char* exception::what() const throw(){
+	_UCXXEXPORT const char* exception::what() const {
 		return __std_exception_what_value;
 	}
 
-	_UCXXEXPORT bad_exception::~bad_exception() throw(){
+	_UCXXEXPORT bad_exception::~bad_exception() {
 
 	}
 

--- a/src/ios
+++ b/src/ios
@@ -40,7 +40,7 @@ namespace std{
 		public:
 			explicit failure(const std::string&) { }
 			explicit failure() { }
-			virtual const char* what() const throw() {
+			virtual const char* what() const {
 				return "std::ios_base failure exception";
 			}
 		};

--- a/src/iterator
+++ b/src/iterator
@@ -145,10 +145,10 @@ namespace std{
 			charT operator*() { return val; }
 		};
 
-		istreambuf_iterator() throw() : sbuf(0) { }
-		istreambuf_iterator(istream_type& s) throw() : sbuf(s.rdbuf()) { }
-		istreambuf_iterator(streambuf_type* s) throw() : sbuf(s) { }
-		istreambuf_iterator(const proxy& p) throw() : sbuf(&p.buf) { }
+		istreambuf_iterator() : sbuf(0) { }
+		istreambuf_iterator(istream_type& s) : sbuf(s.rdbuf()) { }
+		istreambuf_iterator(streambuf_type* s) : sbuf(s) { }
+		istreambuf_iterator(const proxy& p) : sbuf(&p.buf) { }
 
 		charT operator*() const{
 			return sbuf->sgetc();
@@ -196,8 +196,8 @@ namespace std{
 		typedef basic_streambuf<charT,traits> streambuf_type;
 		typedef basic_ostream<charT,traits>   ostream_type;
 	public:
-		ostreambuf_iterator(ostream_type& s) throw() : sbuf(s.rdbuf()), f(false) { }
-		ostreambuf_iterator(streambuf_type* s) throw() : sbuf(s), f(false) { }
+		ostreambuf_iterator(ostream_type& s) : sbuf(s.rdbuf()), f(false) { }
+		ostreambuf_iterator(streambuf_type* s) : sbuf(s), f(false) { }
 		ostreambuf_iterator& operator=(charT c){
 			if(failed() == false){
 				if(sbuf->sputc(c) == traits::eof()){
@@ -211,7 +211,7 @@ namespace std{
 		}
 		ostreambuf_iterator& operator++() { return *this; }
 		ostreambuf_iterator operator++(int) { return *this; }
-		bool failed() const throw(){
+		bool failed() const {
 			return f;
 		}
 

--- a/src/locale
+++ b/src/locale
@@ -42,21 +42,21 @@ namespace std{
 		all = collate | ctype | monetary | numeric | time  | messages;
 
 		// construct/copy/destroy:
-		locale() throw(){
+		locale() {
 			return;
 		}
-		locale(const locale& other) throw(){
+		locale(const locale& other) {
 			(void)other;
 			return;
 		}
-		locale(const char *) throw(){
+		locale(const char *) {
 			return;
 		}
-		~locale() throw(){
+		~locale() {
 			return;
 		}
 
-		const locale& operator=(const locale&) throw(){
+		const locale& operator=(const locale&) {
 			return *this;
 		}
 		std::string name() const { return "C"; }

--- a/src/memory
+++ b/src/memory
@@ -57,9 +57,9 @@ public:
 	pointer address(reference r) const { return &r; }
 	const_pointer address(const_reference r) const { return &r; }
 	
-	allocator() throw(){}
-	template <class U> allocator(const allocator<U>& ) throw();
-	~allocator() throw(){}
+	allocator() {}
+	template <class U> allocator(const allocator<U>& );
+	~allocator() {}
 
 	//Space for n Ts
 	pointer allocate(size_type n, typename allocator<void>::const_pointer = 0){
@@ -73,7 +73,7 @@ public:
 	void construct(pointer p, const T& val) { new((void*)p) T(val); }
 	void destroy(pointer p){ ((T*)p)->~T(); }	//Call destructor
 
-	size_type max_size() const throw();
+	size_type max_size() const ;
 	template<class U> struct rebind { typedef allocator<U> other; };
 
 };
@@ -128,13 +128,13 @@ public:
 
 	typedef T element_type;
 
-	explicit auto_ptr(T* p =0) throw() : object(p){  }
-	auto_ptr(auto_ptr& p) throw() : object(p.release()){ }
-	auto_ptr(auto_ptr_ref<T> r) throw() : object(r.p){
+	explicit auto_ptr(T* p =0) : object(p){  }
+	auto_ptr(auto_ptr& p) : object(p.release()){ }
+	auto_ptr(auto_ptr_ref<T> r) : object(r.p){
 		r.p = 0;
 	}
-	template<class Y> auto_ptr(auto_ptr<Y>& p) throw() : object(p.release()){ }
-	auto_ptr& operator=(auto_ptr& p) throw(){
+	template<class Y> auto_ptr(auto_ptr<Y>& p) : object(p.release()){ }
+	auto_ptr& operator=(auto_ptr& p) {
 		if(&p == this){
 			return *this;
 		}
@@ -142,7 +142,7 @@ public:
 		object = p.release();
 		return *this;
 	}
-	template<class Y> auto_ptr& operator=(auto_ptr<Y>& p) throw(){
+	template<class Y> auto_ptr& operator=(auto_ptr<Y>& p) {
 		if(&p == this){
 			return *this;
 		}
@@ -154,33 +154,33 @@ public:
 		delete object;
 	}
 
-	T& operator*() const throw(){
+	T& operator*() const {
 		return *object;
 	}
-	T* operator->() const throw(){
+	T* operator->() const {
 		return object;
 	}
-	T* get() const throw(){
+	T* get() const {
 		return object;
 	}
-	T* release() throw(){
+	T* release() {
 		T * temp(object);
 		object = 0;
 		return temp;
 	}
-	void reset(T * p=0) throw(){
+	void reset(T * p=0) {
 		if(p != object){
 			delete object;
 			object = p;
 		}
 	}
-	template<class Y> operator auto_ptr_ref<Y>() throw(){
+	template<class Y> operator auto_ptr_ref<Y>() {
 		auto_ptr_ref<Y> retval;
 		retval.p = object;
 		object = 0;
 		return retval;
 	}
-	template<class Y> operator auto_ptr<Y>() throw(){
+	template<class Y> operator auto_ptr<Y>() {
 		auto_ptr<Y> retval(object);
 		object = 0;
 		return retval;

--- a/src/new
+++ b/src/new
@@ -33,36 +33,36 @@ namespace std{
 	extern const nothrow_t nothrow;
 
 	typedef void (*new_handler)();
-	_UCXXEXPORT new_handler set_new_handler(new_handler new_p) throw();
+	_UCXXEXPORT new_handler set_new_handler(new_handler new_p);
 }
 
 
-_UCXXEXPORT void* operator new(std::size_t numBytes) throw(std::bad_alloc);
-_UCXXEXPORT void operator delete(void* ptr) throw();
+_UCXXEXPORT void* operator new(std::size_t numBytes);
+_UCXXEXPORT void operator delete(void* ptr);
 #if __cpp_sized_deallocation
-_UCXXEXPORT void operator delete(void* ptr, std::size_t) throw();
+_UCXXEXPORT void operator delete(void* ptr, std::size_t);
 #endif
 
-_UCXXEXPORT void* operator new[](std::size_t numBytes) throw(std::bad_alloc);
-_UCXXEXPORT void operator delete[](void * ptr) throw();
+_UCXXEXPORT void* operator new[](std::size_t numBytes);
+_UCXXEXPORT void operator delete[](void * ptr);
 #if __cpp_sized_deallocation
-_UCXXEXPORT void operator delete[](void * ptr, std::size_t) throw();
+_UCXXEXPORT void operator delete[](void * ptr, std::size_t);
 #endif
 
 #ifndef NO_NOTHROW
-_UCXXEXPORT void* operator new(std::size_t numBytes, const std::nothrow_t& ) throw();
-_UCXXEXPORT void operator delete(void* ptr, const std::nothrow_t& ) throw();
+_UCXXEXPORT void* operator new(std::size_t numBytes, const std::nothrow_t& );
+_UCXXEXPORT void operator delete(void* ptr, const std::nothrow_t& );
 
-_UCXXEXPORT void* operator new[](std::size_t numBytes, const std::nothrow_t& ) throw();
-_UCXXEXPORT void operator delete[](void* ptr, const std::nothrow_t& ) throw();
+_UCXXEXPORT void* operator new[](std::size_t numBytes, const std::nothrow_t& );
+_UCXXEXPORT void operator delete[](void* ptr, const std::nothrow_t& );
 #endif
 
 	/* Placement operators */
-inline void* operator new(std::size_t, void* ptr) throw() {return ptr; }
-inline void operator delete(void* , void *) throw() { }
+inline void* operator new(std::size_t, void* ptr) {return ptr; }
+inline void operator delete(void* , void *) { }
 	
-inline void* operator new[](std::size_t, void *p) throw() { return p; }
-inline void operator delete[](void* , void *) throw() {}
+inline void* operator new[](std::size_t, void *p) { return p; }
+inline void operator delete[](void* , void *) {}
 
 #pragma GCC visibility pop
 

--- a/src/stdexcept
+++ b/src/stdexcept
@@ -37,11 +37,11 @@ class _UCXXEXPORT logic_error : public exception {
 protected:
 	string mstring;
 public:
-	logic_error() throw();
+	logic_error();
 	logic_error(const string& what_arg);
 
-	virtual ~logic_error() throw() {}
-	virtual const char * what() const throw();
+	virtual ~logic_error() {}
+	virtual const char * what() const;
 
 };	
 
@@ -49,28 +49,28 @@ class _UCXXEXPORT domain_error : public logic_error {
 public:
 	domain_error() : logic_error() {}
 	domain_error(const string& what_arg) : logic_error(what_arg) {}
-	virtual ~domain_error() throw() {}
+	virtual ~domain_error() {}
 };
 
 class _UCXXEXPORT invalid_argument : public logic_error {
 public:
 	invalid_argument() : logic_error(){}
 	invalid_argument(const string& what_arg) : logic_error(what_arg){}
-	virtual ~invalid_argument() throw() {}
+	virtual ~invalid_argument() {}
 };
 
 class _UCXXEXPORT length_error : public logic_error {
 public:
 	length_error() : logic_error(){}
 	length_error(const string& what_arg) : logic_error(what_arg){}
-	virtual ~length_error() throw() {}
+	virtual ~length_error() {}
 };
 
 class _UCXXEXPORT out_of_range : public logic_error{
 public:
 	out_of_range();
 	out_of_range(const string & what_arg);
-	virtual ~out_of_range() throw() {}
+	virtual ~out_of_range() {}
 
 };
 
@@ -81,15 +81,15 @@ public:
 	runtime_error();
 	runtime_error(const string& what_arg);
 
-	virtual ~runtime_error() throw() {}
-	virtual const char * what() const throw();
+	virtual ~runtime_error() {}
+	virtual const char * what() const;
 };
 
 class _UCXXEXPORT range_error : public runtime_error{
 public:
 	range_error() : runtime_error(){}
 	range_error(const string& what_arg) : runtime_error(what_arg) {}
-	virtual ~range_error() throw(){ }
+	virtual ~range_error() { }
 };
 
 
@@ -97,14 +97,14 @@ class _UCXXEXPORT overflow_error : public runtime_error{
 public:
 	overflow_error() : runtime_error(){}
 	overflow_error(const string& what_arg) : runtime_error(what_arg) {}
-	virtual ~overflow_error() throw(){}
+	virtual ~overflow_error() {}
 };
 
 class _UCXXEXPORT underflow_error : public runtime_error{
 public:
 	underflow_error() : runtime_error(){}
 	underflow_error(const string& what_arg) : runtime_error(what_arg) {}
-	virtual ~underflow_error() throw(){}
+	virtual ~underflow_error() {}
 };
 
 

--- a/src/typeinfo.cpp
+++ b/src/typeinfo.cpp
@@ -21,11 +21,11 @@
 
 namespace std{
 
-	_UCXXEXPORT bad_cast::~bad_cast() throw(){
+	_UCXXEXPORT bad_cast::~bad_cast() {
 
 	}
 
-	_UCXXEXPORT bad_typeid::~bad_typeid() throw(){
+	_UCXXEXPORT bad_typeid::~bad_typeid() {
 
 	}
 

--- a/src/unwind-cxx.h
+++ b/src/unwind-cxx.h
@@ -140,18 +140,18 @@ struct __cxa_eh_globals
 // either of the following functions.  The "fast" version assumes at least
 // one prior call of __cxa_get_globals has been made from the current
 // thread, so no initialization is necessary.
-extern "C" __cxa_eh_globals *__cxa_get_globals () throw();
-extern "C" __cxa_eh_globals *__cxa_get_globals_fast () throw();
+extern "C" __cxa_eh_globals *__cxa_get_globals ();
+extern "C" __cxa_eh_globals *__cxa_get_globals_fast ();
 
 // Allocate memory for the primary exception plus the thrown object.
-extern "C" void *__cxa_allocate_exception(std::size_t thrown_size) throw();
+extern "C" void *__cxa_allocate_exception(std::size_t thrown_size);
 // Allocate memory for dependent exception.
-extern "C" __cxa_dependent_exception *__cxa_allocate_dependent_exception() throw();
+extern "C" __cxa_dependent_exception *__cxa_allocate_dependent_exception();
 
 // Free the space allocated for the primary exception.
-extern "C" void __cxa_free_exception(void *thrown_exception) throw();
+extern "C" void __cxa_free_exception(void *thrown_exception);
 // Free the space allocated for the dependent exception.
-extern "C" void __cxa_free_dependent_exception(__cxa_dependent_exception *dependent_exception) throw();
+extern "C" void __cxa_free_dependent_exception(__cxa_dependent_exception *dependent_exception);
 
 // Throw the exception.
 extern "C" void __cxa_throw (void *thrown_exception,
@@ -160,7 +160,7 @@ extern "C" void __cxa_throw (void *thrown_exception,
      __attribute__((noreturn));
 
 // Used to implement exception handlers.
-extern "C" void *__cxa_begin_catch (void *) throw();
+extern "C" void *__cxa_begin_catch (void *);
 extern "C" void __cxa_end_catch ();
 extern "C" void __cxa_rethrow () __attribute__((noreturn));
 


### PR DESCRIPTION
Dynamic exception spefications are deprecated since C++11 and removed in
C++17 / C++20 (depending on the type). This change removes them, and prevents
the warnings they caused.